### PR TITLE
Release 1.8.1

### DIFF
--- a/toolkit/event-observer/src/test/kotlin/br/com/arch/toolkit/util/ChainTest.kt
+++ b/toolkit/event-observer/src/test/kotlin/br/com/arch/toolkit/util/ChainTest.kt
@@ -247,7 +247,7 @@ class ChainTest {
                 coVerify(exactly = 1) { condition("String") }
                 coVerify(exactly = 1) { liveData("String") }
                 coVerify(exactly = 1) { transform("String", 123) }
-                coVerify(exactly = 1) { observer(null) }
+                coVerify(exactly = 0) { observer(any()) }
             }
         )
     //endregion

--- a/toolkit/event-observer/src/test/kotlin/br/com/arch/toolkit/util/CombineTest.kt
+++ b/toolkit/event-observer/src/test/kotlin/br/com/arch/toolkit/util/CombineTest.kt
@@ -110,7 +110,7 @@ class CombineTest {
         liveDataB = MutableLiveData(123),
         transformException = true,
         block = { _, _, _, mockedObserver ->
-            coVerify(exactly = 1) { mockedObserver.invoke(null) }
+            coVerify(exactly = 0) { mockedObserver.invoke(any()) }
         }
     )
     //endregion


### PR DESCRIPTION
Discussão

Pro combine e pro chainWith normais (LiveData com LiveData)

Quando o bloco "transform" dá erro, ele posta null no lugar... essa alteração meio que omite quando dá um erro apenas.